### PR TITLE
WIP: Tap on Backgrounds for DateEvents and AllDayEvents (draft)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,11 +96,8 @@ class _TimetableExampleState extends State<TimetableExample> {
       ),
       body: Timetable<BasicEvent>(
         controller: _controller,
-        onAllDayEventBackgroundTap: (start, isAllDay) {
-          _showSnackBar('Background of all day event tapped $start');
-        },
         onEventBackgroundTap: (start, isAllDay) {
-          _showSnackBar('Background tapped $start');
+          _showSnackBar('Background tapped $start is all day event $isAllDay');
         },
         eventBuilder: (event) {
           return BasicEventWidget(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,6 +96,9 @@ class _TimetableExampleState extends State<TimetableExample> {
       ),
       body: Timetable<BasicEvent>(
         controller: _controller,
+        onCreateEvent: (start, isAllDay) {
+          _showSnackBar('Background tapped $start');
+        },
         eventBuilder: (event) {
           return BasicEventWidget(
             event,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,10 +96,10 @@ class _TimetableExampleState extends State<TimetableExample> {
       ),
       body: Timetable<BasicEvent>(
         controller: _controller,
-        onCreateAllDayEvent: (start, isAllDay) {
+        onAllDayEventBackgroundTap: (start, isAllDay) {
           _showSnackBar('Background of all day event tapped $start');
         },
-        onCreateEvent: (start, isAllDay) {
+        onEventBackgroundTap: (start, isAllDay) {
           _showSnackBar('Background tapped $start');
         },
         eventBuilder: (event) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,6 +96,9 @@ class _TimetableExampleState extends State<TimetableExample> {
       ),
       body: Timetable<BasicEvent>(
         controller: _controller,
+        onCreateAllDayEvent: (start, isAllDay) {
+          _showSnackBar('Background of all day event tapped $start');
+        },
         onCreateEvent: (start, isAllDay) {
           _showSnackBar('Background tapped $start');
         },

--- a/lib/src/content/date_events.dart
+++ b/lib/src/content/date_events.dart
@@ -116,7 +116,6 @@ class _DayEventsLayoutDelegate<E extends Event>
 
     for (final event in events) {
       final position = positions.eventPositions[event];
-
       final top = timeToY(event.start)
           .coerceAtMost(size.height - periodToY(minEventDuration))
           .coerceAtMost(size.height - minEventHeight);

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -64,20 +64,7 @@ class _MultiDateContentState<E extends Event>
                 behavior: HitTestBehavior.translucent,
                 onTapUp: widget.onEventBackgroundTap != null
                     ? (details) {
-                        final tappedCell = details.localPosition.dy /
-                            ((constraints.maxHeight / 24).round());
-                        final minutesAsQuarter = (tappedCell * 4).ceil() / 4;
-                        final digitValue = minutesAsQuarter
-                            .toString()
-                            .split('.')[1]
-                            .padRight(2, '0');
-                        final minutesOfTap =
-                            60 * (double.parse(digitValue) / 100);
-                        final startTime = LocalTime.sinceMidnight(Time(
-                                hours: tappedCell.toInt(),
-                                minutes: minutesOfTap))
-                            .atDate(date);
-                        _callOnEventBackgroundTap(startTime, false);
+                        _callOnEventBackgroundTap(details, date, constraints);
                       }
                     : null,
                 child: StreamedDateEvents<E>(
@@ -93,9 +80,14 @@ class _MultiDateContentState<E extends Event>
     );
   }
 
-  void _callOnEventBackgroundTap(LocalDateTime startTime, bool isAllDay) {
-    if (widget.onEventBackgroundTap != null) {
-      widget.onEventBackgroundTap(startTime, isAllDay);
-    }
+  void _callOnEventBackgroundTap(TapUpDetails details, LocalDate date, BoxConstraints constraints) {
+    final millis = details.localPosition.dy /
+        constraints.maxHeight *
+        TimeConstants.millisecondsPerDay;
+    final startTime = LocalTime.sinceMidnight(
+        Time(milliseconds: millis.floor()))
+        .atDate(date);
+      widget.onEventBackgroundTap(startTime, false);
+
   }
 }

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -1,5 +1,6 @@
 import 'package:black_hole_flutter/black_hole_flutter.dart';
 import 'package:flutter/widgets.dart';
+import 'package:time_machine/time_machine.dart';
 
 import '../controller.dart';
 import '../date_page_view.dart';
@@ -57,17 +58,22 @@ class _MultiDateContentState<E extends Event>
       child: DatePageView(
         controller: widget.controller,
         builder: (_, date) {
-          return GestureDetector(
+          return LayoutBuilder(
+          builder: (context, constraints) {
+             return GestureDetector(
               behavior: HitTestBehavior.translucent,
-              onTap: () {
-                print(date);
-               // widget.onCreateEvent(null, false);
+              onTapUp: (details) {
+                final cell = details.localPosition.dy / ((constraints.heightConstraints() / 24).maxHeight);
+                final time = DateTime(date.year, date.monthOfYear, date.dayOfYear, cell.toInt());
+                final startTime = LocalDateTime.dateTime(time);
+                print(startTime);
+            //    widget.onCreateEvent(startTime, false);
               },
               child: StreamedDateEvents<E>(
                 date: date,
                 controller: widget.controller,
                 eventBuilder: widget.eventBuilder,
-              ));
+              ));});
         },
       ),
     );

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -63,9 +63,9 @@ class _MultiDateContentState<E extends Event>
              return GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTapUp: (details) {
-                final cell = details.localPosition.dy / ((constraints.maxHeight / 24).round());
-                final time = DateTime(date.year, date.monthOfYear, date.dayOfYear, cell.toInt() + 1);
-                final startTime = LocalDateTime.dateTime(time);
+                final tappedCell = details.localPosition.dy / ((constraints.maxHeight / 24).round());
+                final dateAndTime = DateTime(date.year, date.monthOfYear, date.dayOfYear, tappedCell.toInt() + 1);
+                final startTime = LocalDateTime.dateTime(dateAndTime);
 
                 if(widget.onCreateEvent != null) {
                   widget.onCreateEvent(startTime, false);

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -16,12 +16,14 @@ class MultiDateContent<E extends Event> extends StatefulWidget {
     Key key,
     @required this.controller,
     @required this.eventBuilder,
+    @required this.onCreateEvent,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final EventBuilder<E> eventBuilder;
+  final OnCreateEventCallback onCreateEvent;
 
   @override
   _MultiDateContentState<E> createState() => _MultiDateContentState<E>();
@@ -42,7 +44,6 @@ class _MultiDateContentState<E extends Event>
   Widget build(BuildContext context) {
     final theme = context.theme;
     final timetableTheme = context.timetableTheme;
-
     return CustomPaint(
       painter: MultiDateBackgroundPainter(
         controller: widget.controller,
@@ -56,11 +57,17 @@ class _MultiDateContentState<E extends Event>
       child: DatePageView(
         controller: widget.controller,
         builder: (_, date) {
-          return StreamedDateEvents<E>(
-            date: date,
-            controller: widget.controller,
-            eventBuilder: widget.eventBuilder,
-          );
+          return GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: () {
+                print(date);
+               // widget.onCreateEvent(null, false);
+              },
+              child: StreamedDateEvents<E>(
+                date: date,
+                controller: widget.controller,
+                eventBuilder: widget.eventBuilder,
+              ));
         },
       ),
     );

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -17,7 +17,7 @@ class MultiDateContent<E extends Event> extends StatefulWidget {
     Key key,
     @required this.controller,
     @required this.eventBuilder,
-    @required this.onCreateEvent,
+    this.onCreateEvent,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);
@@ -66,8 +66,10 @@ class _MultiDateContentState<E extends Event>
                 final cell = details.localPosition.dy / ((constraints.maxHeight / 24).round());
                 final time = DateTime(date.year, date.monthOfYear, date.dayOfYear, cell.toInt() + 1);
                 final startTime = LocalDateTime.dateTime(time);
-                print(startTime);
-            //    widget.onCreateEvent(startTime, false);
+
+                if(widget.onCreateEvent != null) {
+                  widget.onCreateEvent(startTime, false);
+                }
               },
               child: StreamedDateEvents<E>(
                 date: date,

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -65,10 +65,7 @@ class _MultiDateContentState<E extends Event>
                 final tappedCell = details.localPosition.dy /
                     ((constraints.maxHeight / 24).round());
 
-                final dateAndTime = DateTime(date.year, date.monthOfYear,
-                    date.dayOfYear, tappedCell.toInt() + 1);
-                final startTime = LocalDateTime.dateTime(dateAndTime);
-
+                final startTime = LocalTime.sinceMidnight(Time(hours: tappedCell.toInt())).atDate(date);
                 _callOnCreateEvent(startTime, false);
 
               } : null,

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -58,16 +58,17 @@ class _MultiDateContentState<E extends Event>
       child: DatePageView(
         controller: widget.controller,
         builder: (_, date) {
-          return LayoutBuilder(
-          builder: (context, constraints) {
-             return GestureDetector(
+          return LayoutBuilder(builder: (context, constraints) {
+            return GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTapUp: (details) {
-                final tappedCell = details.localPosition.dy / ((constraints.maxHeight / 24).round());
-                final dateAndTime = DateTime(date.year, date.monthOfYear, date.dayOfYear, tappedCell.toInt() + 1);
+                final tappedCell = details.localPosition.dy /
+                    ((constraints.maxHeight / 24).round());
+                final dateAndTime = DateTime(date.year, date.monthOfYear,
+                    date.dayOfYear, tappedCell.toInt() + 1);
                 final startTime = LocalDateTime.dateTime(dateAndTime);
 
-                if(widget.onCreateEvent != null) {
+                if (widget.onCreateEvent != null) {
                   widget.onCreateEvent(startTime, false);
                 }
               },
@@ -75,7 +76,9 @@ class _MultiDateContentState<E extends Event>
                 date: date,
                 controller: widget.controller,
                 eventBuilder: widget.eventBuilder,
-              ));});
+              ),
+            );
+          });
         },
       ),
     );

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -61,17 +61,17 @@ class _MultiDateContentState<E extends Event>
           return LayoutBuilder(builder: (context, constraints) {
             return GestureDetector(
               behavior: HitTestBehavior.translucent,
-              onTapUp: (details) {
+              onTapUp: widget.onCreateEvent != null ? (details) {
                 final tappedCell = details.localPosition.dy /
                     ((constraints.maxHeight / 24).round());
+
                 final dateAndTime = DateTime(date.year, date.monthOfYear,
                     date.dayOfYear, tappedCell.toInt() + 1);
                 final startTime = LocalDateTime.dateTime(dateAndTime);
 
-                if (widget.onCreateEvent != null) {
-                  widget.onCreateEvent(startTime, false);
-                }
-              },
+                _callOnCreateEvent(startTime, false);
+
+              } : null,
               child: StreamedDateEvents<E>(
                 date: date,
                 controller: widget.controller,
@@ -82,5 +82,11 @@ class _MultiDateContentState<E extends Event>
         },
       ),
     );
+  }
+
+  void _callOnCreateEvent(LocalDateTime startTime, bool isAllDay){
+    if (widget.onCreateEvent != null) {
+      widget.onCreateEvent(startTime, isAllDay);
+    }
   }
 }

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -63,8 +63,8 @@ class _MultiDateContentState<E extends Event>
              return GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTapUp: (details) {
-                final cell = details.localPosition.dy / ((constraints.heightConstraints() / 24).maxHeight);
-                final time = DateTime(date.year, date.monthOfYear, date.dayOfYear, cell.toInt());
+                final cell = details.localPosition.dy / ((constraints.maxHeight / 24).round());
+                final time = DateTime(date.year, date.monthOfYear, date.dayOfYear, cell.toInt() + 1);
                 final startTime = LocalDateTime.dateTime(time);
                 print(startTime);
             //    widget.onCreateEvent(startTime, false);

--- a/lib/src/content/multi_date_content.dart
+++ b/lib/src/content/multi_date_content.dart
@@ -24,7 +24,7 @@ class MultiDateContent<E extends Event> extends StatefulWidget {
 
   final TimetableController<E> controller;
   final EventBuilder<E> eventBuilder;
-  final OnCreateEventCallback onEventBackgroundTap;
+  final OnEventBackgroundTapCallback onEventBackgroundTap;
 
   @override
   _MultiDateContentState<E> createState() => _MultiDateContentState<E>();

--- a/lib/src/content/timetable_content.dart
+++ b/lib/src/content/timetable_content.dart
@@ -22,7 +22,7 @@ class TimetableContent<E extends Event> extends StatelessWidget {
 
   final TimetableController<E> controller;
   final EventBuilder<E> eventBuilder;
-  final OnCreateEventCallback onEventBackgroundTap;
+  final OnEventBackgroundTapCallback onEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/content/timetable_content.dart
+++ b/lib/src/content/timetable_content.dart
@@ -15,12 +15,14 @@ class TimetableContent<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.eventBuilder,
+    @required this.onCreateEvent,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final EventBuilder<E> eventBuilder;
+  final OnCreateEventCallback onCreateEvent;
 
   @override
   Widget build(BuildContext context) {
@@ -53,6 +55,7 @@ class TimetableContent<E extends Event> extends StatelessWidget {
             child: MultiDateContent<E>(
               controller: controller,
               eventBuilder: eventBuilder,
+              onCreateEvent: onCreateEvent
             ),
           ),
         ],

--- a/lib/src/content/timetable_content.dart
+++ b/lib/src/content/timetable_content.dart
@@ -15,14 +15,14 @@ class TimetableContent<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.eventBuilder,
-    this.onCreateEvent,
+    this.onEventBackgroundTap,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final EventBuilder<E> eventBuilder;
-  final OnCreateEventCallback onCreateEvent;
+  final OnCreateEventCallback onEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +55,7 @@ class TimetableContent<E extends Event> extends StatelessWidget {
             child: MultiDateContent<E>(
               controller: controller,
               eventBuilder: eventBuilder,
-              onCreateEvent: onCreateEvent
+              onEventBackgroundTap: onEventBackgroundTap
             ),
           ),
         ],

--- a/lib/src/content/timetable_content.dart
+++ b/lib/src/content/timetable_content.dart
@@ -15,7 +15,7 @@ class TimetableContent<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.eventBuilder,
-    @required this.onCreateEvent,
+    this.onCreateEvent,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);

--- a/lib/src/header/all_day_events.dart
+++ b/lib/src/header/all_day_events.dart
@@ -57,9 +57,9 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
                                 controller.visibleRange.visibleDays);
                         final date = LocalDate.fromEpochDay(
                             page.floor() + tappedCell.toInt());
-                        final dateAndTime = DateTime(
-                            date.year, date.monthOfYear, date.dayOfYear + 2);
-                        final startTime = LocalDateTime.dateTime(dateAndTime);
+
+                        final startTime = LocalTime.sinceMidnight(Time(hours: 0)).atDate(date);
+
                         _callOnCreateAllDayEvent(startTime, true);
                       } : null,
                       child: _buildEventLayout(context, events, page),

--- a/lib/src/header/all_day_events.dart
+++ b/lib/src/header/all_day_events.dart
@@ -51,17 +51,12 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
                         controller.scrollControllers.pageListenable,
                     builder: (context, page, __) => GestureDetector(
                       behavior: HitTestBehavior.translucent,
-                      onTapUp: onAllDayEventBackgroundTap != null ? (details) {
-                        final tappedCell = details.localPosition.dx /
-                            (constraints.maxWidth /
-                                controller.visibleRange.visibleDays);
-                        final date = LocalDate.fromEpochDay(
-                            (page + tappedCell).floor());
-
-                        final startTime = LocalTime.sinceMidnight(Time(hours: 0)).atDate(date);
-
-                        _callOnAllDayEventBackgroundTap(startTime, true);
-                      } : null,
+                      onTapUp: onAllDayEventBackgroundTap != null
+                          ? (details) {
+                              _callOnAllDayEventBackgroundTap(
+                                  details, page, constraints);
+                            }
+                          : null,
                       child: _buildEventLayout(context, events, page),
                     ),
                   );
@@ -74,10 +69,12 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
     );
   }
 
-  void _callOnAllDayEventBackgroundTap(LocalDateTime startTime, bool isAllDay){
-    if (onAllDayEventBackgroundTap != null) {
-      onAllDayEventBackgroundTap(startTime, isAllDay);
-    }
+  void _callOnAllDayEventBackgroundTap(TapUpDetails details, double page, BoxConstraints constraints) {
+    final tappedCell = details.localPosition.dx /
+        (constraints.maxWidth / controller.visibleRange.visibleDays);
+    final date = LocalDate.fromEpochDay((page + tappedCell).floor());
+    final startTime = date.atMidnight();
+    onAllDayEventBackgroundTap(startTime, true);
   }
 
   Widget _buildEventLayout(

--- a/lib/src/header/all_day_events.dart
+++ b/lib/src/header/all_day_events.dart
@@ -19,14 +19,14 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.allDayEventBuilder,
-    this.onCreateAllDayEvent,
+    this.onAllDayEventBackgroundTap,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
-  final OnCreateEventCallback onCreateAllDayEvent;
+  final OnCreateEventCallback onAllDayEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -51,16 +51,16 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
                         controller.scrollControllers.pageListenable,
                     builder: (context, page, __) => GestureDetector(
                       behavior: HitTestBehavior.translucent,
-                      onTapUp: onCreateAllDayEvent != null ? (details) {
+                      onTapUp: onAllDayEventBackgroundTap != null ? (details) {
                         final tappedCell = details.localPosition.dx /
                             (constraints.maxWidth /
                                 controller.visibleRange.visibleDays);
                         final date = LocalDate.fromEpochDay(
-                            page.floor() + tappedCell.toInt());
+                            (page + tappedCell).floor());
 
                         final startTime = LocalTime.sinceMidnight(Time(hours: 0)).atDate(date);
 
-                        _callOnCreateAllDayEvent(startTime, true);
+                        _callOnAllDayEventBackgroundTap(startTime, true);
                       } : null,
                       child: _buildEventLayout(context, events, page),
                     ),
@@ -74,9 +74,9 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
     );
   }
 
-  void _callOnCreateAllDayEvent(LocalDateTime startTime, bool isAllDay){
-    if (onCreateAllDayEvent != null) {
-      onCreateAllDayEvent(startTime, isAllDay);
+  void _callOnAllDayEventBackgroundTap(LocalDateTime startTime, bool isAllDay){
+    if (onAllDayEventBackgroundTap != null) {
+      onAllDayEventBackgroundTap(startTime, isAllDay);
     }
   }
 

--- a/lib/src/header/all_day_events.dart
+++ b/lib/src/header/all_day_events.dart
@@ -19,14 +19,14 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.allDayEventBuilder,
-    this.onAllDayEventBackgroundTap,
+    this.onEventBackgroundTap,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
-  final OnCreateEventCallback onAllDayEventBackgroundTap;
+  final OnEventBackgroundTapCallback onEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +51,7 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
                         controller.scrollControllers.pageListenable,
                     builder: (context, page, __) => GestureDetector(
                       behavior: HitTestBehavior.translucent,
-                      onTapUp: onAllDayEventBackgroundTap != null
+                      onTapUp: onEventBackgroundTap != null
                           ? (details) {
                               _callOnAllDayEventBackgroundTap(
                                   details, page, constraints);
@@ -74,7 +74,7 @@ class AllDayEvents<E extends Event> extends StatelessWidget {
         (constraints.maxWidth / controller.visibleRange.visibleDays);
     final date = LocalDate.fromEpochDay((page + tappedCell).floor());
     final startTime = date.atMidnight();
-    onAllDayEventBackgroundTap(startTime, true);
+    onEventBackgroundTap(startTime, true);
   }
 
   Widget _buildEventLayout(

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -14,14 +14,14 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.allDayEventBuilder,
-    this.onCreateEvent,
+    this.onCreateAllDayEvent,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
-  final OnCreateEventCallback onCreateEvent;
+  final OnCreateEventCallback onCreateAllDayEvent;
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +51,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
               ),
               AllDayEvents<E>(
                 controller: controller,
+                onCreateAllDayEvent: onCreateAllDayEvent,
                 allDayEventBuilder: allDayEventBuilder,
               ),
             ],

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -14,12 +14,14 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.allDayEventBuilder,
+    this.onCreateEvent,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
+  final OnCreateEventCallback onCreateEvent;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -14,14 +14,14 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.allDayEventBuilder,
-    this.onCreateAllDayEvent,
+    this.onAllDayEventBackgroundTap,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
-  final OnCreateEventCallback onCreateAllDayEvent;
+  final OnCreateEventCallback onAllDayEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +51,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
               ),
               AllDayEvents<E>(
                 controller: controller,
-                onCreateAllDayEvent: onCreateAllDayEvent,
+                onAllDayEventBackgroundTap: onAllDayEventBackgroundTap,
                 allDayEventBuilder: allDayEventBuilder,
               ),
             ],

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -14,14 +14,14 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.allDayEventBuilder,
-    this.onAllDayEventBackgroundTap,
+    this.onEventBackgroundTap,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
 
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
-  final OnCreateEventCallback onAllDayEventBackgroundTap;
+  final OnEventBackgroundTapCallback onEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +51,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
               ),
               AllDayEvents<E>(
                 controller: controller,
-                onAllDayEventBackgroundTap: onAllDayEventBackgroundTap,
+                onEventBackgroundTap: onEventBackgroundTap,
                 allDayEventBuilder: allDayEventBuilder,
               ),
             ],

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:time_machine/time_machine.dart';
 
 import 'all_day.dart';
 import 'content/timetable_content.dart';
@@ -9,6 +10,7 @@ import 'header/timetable_header.dart';
 import 'theme.dart';
 
 typedef EventBuilder<E extends Event> = Widget Function(E event);
+typedef OnCreateEventCallback = void Function(LocalDateTime start, bool isAllDay);
 typedef AllDayEventBuilder<E extends Event> = Widget Function(
   BuildContext context,
   E event,
@@ -18,11 +20,13 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
 const double hourColumnWidth = 48;
 
 class Timetable<E extends Event> extends StatelessWidget {
+
   const Timetable({
     Key key,
     @required this.controller,
     @required this.eventBuilder,
     this.allDayEventBuilder,
+    this.onCreateEvent,
     this.theme,
   })  : assert(controller != null),
         assert(eventBuilder != null),
@@ -35,8 +39,8 @@ class Timetable<E extends Event> extends StatelessWidget {
   ///
   /// If not set, [eventBuilder] will be used instead.
   final AllDayEventBuilder<E> allDayEventBuilder;
-
   final TimetableThemeData theme;
+  final OnCreateEventCallback onCreateEvent;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -10,7 +10,7 @@ import 'header/timetable_header.dart';
 import 'theme.dart';
 
 typedef EventBuilder<E extends Event> = Widget Function(E event);
-typedef OnCreateEventCallback = void Function(LocalDateTime start, bool isAllDay);
+typedef OnEventBackgroundTapCallback = void Function(LocalDateTime start, bool isAllDay);
 typedef AllDayEventBuilder<E extends Event> = Widget Function(
   BuildContext context,
   E event,
@@ -27,7 +27,6 @@ class Timetable<E extends Event> extends StatelessWidget {
     @required this.eventBuilder,
     this.allDayEventBuilder,
     this.onEventBackgroundTap,
-    this.onAllDayEventBackgroundTap,
     this.theme,
   })  : assert(controller != null),
         assert(eventBuilder != null),
@@ -41,8 +40,7 @@ class Timetable<E extends Event> extends StatelessWidget {
   /// If not set, [eventBuilder] will be used instead.
   final AllDayEventBuilder<E> allDayEventBuilder;
   final TimetableThemeData theme;
-  final OnCreateEventCallback onEventBackgroundTap;
-  final OnCreateEventCallback onAllDayEventBackgroundTap;
+  final OnEventBackgroundTapCallback onEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +48,7 @@ class Timetable<E extends Event> extends StatelessWidget {
       children: <Widget>[
         TimetableHeader<E>(
           controller: controller,
-          onAllDayEventBackgroundTap: onAllDayEventBackgroundTap,
+          onEventBackgroundTap: onEventBackgroundTap,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),
         ),

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -48,6 +48,7 @@ class Timetable<E extends Event> extends StatelessWidget {
       children: <Widget>[
         TimetableHeader<E>(
           controller: controller,
+          onCreateEvent: onCreateEvent,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),
         ),

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -55,6 +55,7 @@ class Timetable<E extends Event> extends StatelessWidget {
           child: TimetableContent<E>(
             controller: controller,
             eventBuilder: eventBuilder,
+            onCreateEvent: onCreateEvent
           ),
         ),
       ],

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -27,6 +27,7 @@ class Timetable<E extends Event> extends StatelessWidget {
     @required this.eventBuilder,
     this.allDayEventBuilder,
     this.onCreateEvent,
+    this.onCreateAllDayEvent,
     this.theme,
   })  : assert(controller != null),
         assert(eventBuilder != null),
@@ -41,6 +42,7 @@ class Timetable<E extends Event> extends StatelessWidget {
   final AllDayEventBuilder<E> allDayEventBuilder;
   final TimetableThemeData theme;
   final OnCreateEventCallback onCreateEvent;
+  final OnCreateEventCallback onCreateAllDayEvent;
 
   @override
   Widget build(BuildContext context) {
@@ -48,7 +50,7 @@ class Timetable<E extends Event> extends StatelessWidget {
       children: <Widget>[
         TimetableHeader<E>(
           controller: controller,
-          onCreateEvent: onCreateEvent,
+          onCreateAllDayEvent: onCreateAllDayEvent,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),
         ),

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -26,8 +26,8 @@ class Timetable<E extends Event> extends StatelessWidget {
     @required this.controller,
     @required this.eventBuilder,
     this.allDayEventBuilder,
-    this.onCreateEvent,
-    this.onCreateAllDayEvent,
+    this.onEventBackgroundTap,
+    this.onAllDayEventBackgroundTap,
     this.theme,
   })  : assert(controller != null),
         assert(eventBuilder != null),
@@ -41,8 +41,8 @@ class Timetable<E extends Event> extends StatelessWidget {
   /// If not set, [eventBuilder] will be used instead.
   final AllDayEventBuilder<E> allDayEventBuilder;
   final TimetableThemeData theme;
-  final OnCreateEventCallback onCreateEvent;
-  final OnCreateEventCallback onCreateAllDayEvent;
+  final OnCreateEventCallback onEventBackgroundTap;
+  final OnCreateEventCallback onAllDayEventBackgroundTap;
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +50,7 @@ class Timetable<E extends Event> extends StatelessWidget {
       children: <Widget>[
         TimetableHeader<E>(
           controller: controller,
-          onCreateAllDayEvent: onCreateAllDayEvent,
+          onAllDayEventBackgroundTap: onAllDayEventBackgroundTap,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),
         ),
@@ -58,7 +58,7 @@ class Timetable<E extends Event> extends StatelessWidget {
           child: TimetableContent<E>(
             controller: controller,
             eventBuilder: eventBuilder,
-            onCreateEvent: onCreateEvent
+            onEventBackgroundTap: onEventBackgroundTap
           ),
         ),
       ],


### PR DESCRIPTION
**Closes: #18**

I thought I'd issue a pull request at the current state regarding #18.

Background taps are currently recognized across `DateEvents` and `AllDayEvents`. Tapping on headers is currently not implemented yet.
The pull request adapted the example with a snackbar function.

There are some things on my mind and I'm looking forward to your feedback:

1. Is the name `onCreateEvent` and `onCreateAllDayEvent` really appliceable? Maybe we should change it to somehting like `onBackgroundTap` or `onCellTap`?

2. Regarding `DateEvents` I'm not quite sure why when calculating the position of the tapped cell I need to add a `+1` here:

```dart
final dateAndTime = DateTime(date.year, date.monthOfYear, date.dayOfYear, tappedCell.toInt() + 1);
```

3. For allday events I even had to do `+2` for the day.

```dart
final dateAndTime = DateTime(date.year, date.monthOfYear, date.dayOfYear + 2);
```

I'm not really sure about the calculations at all. The offset issue with the days might be related to wrong rounding? Might also be a conversion problem related to `final startTime = LocalDateTime.dateTime(dateAndTime)` I think? Maybe you could shed some light into this and the calculation at all. Also the time of the giving back object is always `23:00:00` eventhough it should be `00:00:00`



4. I think there are still some parts where I could make the code partly more elegant. Advices are appreciated :) !