### PR TITLE
added builders for week indicator and for day header

### DIFF
--- a/lib/src/header/multi_date_header.dart
+++ b/lib/src/header/multi_date_header.dart
@@ -3,23 +3,26 @@ import 'package:flutter/material.dart';
 import '../controller.dart';
 import '../date_page_view.dart';
 import '../event.dart';
+import '../timetable.dart';
 import 'date_header.dart';
 
 class MultiDateHeader<E extends Event> extends StatelessWidget {
   const MultiDateHeader({
     Key key,
     @required this.controller,
+    this.builder,
   })  : assert(controller != null),
         super(key: key);
 
   final TimetableController<E> controller;
+  final HeaderBuilder builder;
 
   @override
   Widget build(BuildContext context) {
     return DatePageView(
       controller: controller,
-      builder: (_, date) {
-        return Center(child: DateHeader(date));
+      builder: (context, date) {
+        return builder?.call(context, date) ?? Center(child: DateHeader(date));
       },
     );
   }

--- a/lib/src/header/multi_date_header.dart
+++ b/lib/src/header/multi_date_header.dart
@@ -15,7 +15,7 @@ class MultiDateHeader<E extends Event> extends StatelessWidget {
         super(key: key);
 
   final TimetableController<E> controller;
-  final HeaderBuilder builder;
+  final HeaderWidgetBuilder builder;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -24,8 +24,8 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
   final OnEventBackgroundTapCallback onEventBackgroundTap;
-  final HeaderBuilder weekIndicatorBuilder;
-  final HeaderBuilder dayHeaderBuilder;
+  final HeaderWidgetBuilder weekIndicatorBuilder;
+  final HeaderWidgetBuilder dayHeaderBuilder;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -16,7 +16,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     @required this.allDayEventBuilder,
     this.onEventBackgroundTap,
     this.weekIndicatorBuilder,
-    this.dayHeaderBuilder,
+    this.dateHeaderBuilder,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
@@ -25,7 +25,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
   final AllDayEventBuilder<E> allDayEventBuilder;
   final OnEventBackgroundTapCallback onEventBackgroundTap;
   final HeaderWidgetBuilder weekIndicatorBuilder;
-  final HeaderWidgetBuilder dayHeaderBuilder;
+  final HeaderWidgetBuilder dateHeaderBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +59,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
                 height: context.timetableTheme?.totalDateIndicatorHeight ?? 72,
                 child: MultiDateHeader(
                   controller: controller,
-                  builder: dayHeaderBuilder,
+                  builder: dateHeaderBuilder,
                 ),
               ),
               AllDayEvents<E>(

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -38,7 +38,6 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
         SizedBox(
           width: hourColumnWidth,
           child: ValueListenableBuilder<LocalDate>(
-              valueListenable: controller.dateListenable,
             valueListenable: controller.dateListenable,
             builder: (context, date, _) {
               final customHeader = weekIndicatorBuilder?.call(context, date);

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -39,12 +39,18 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
           width: hourColumnWidth,
           child: ValueListenableBuilder<LocalDate>(
               valueListenable: controller.dateListenable,
-              builder: (context, date, _) {
-                return weekIndicatorBuilder?.call(context, date) ??
-                    Center(
-                        child: WeekIndicator(
-                            weekYearRule.getWeekOfWeekYear(date)));
-              }),
+            valueListenable: controller.dateListenable,
+            builder: (context, date, _) {
+              final customHeader = weekIndicatorBuilder?.call(context, date);
+              if (customHeader != null) {
+                return customHeader;
+              }
+
+              return Center(
+                child: WeekIndicator(weekYearRule.getWeekOfWeekYear(date)),
+              );
+            },
+          ),
         ),
         Expanded(
           child: Column(

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -15,6 +15,8 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     @required this.controller,
     @required this.allDayEventBuilder,
     this.onEventBackgroundTap,
+    this.weekIndicatorBuilder,
+    this.dayHeaderBuilder,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
         super(key: key);
@@ -22,6 +24,8 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
   final OnEventBackgroundTapCallback onEventBackgroundTap;
+  final HeaderBuilder weekIndicatorBuilder;
+  final HeaderBuilder dayHeaderBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -33,13 +37,14 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
       children: <Widget>[
         SizedBox(
           width: hourColumnWidth,
-          child: Center(
-            child: ValueListenableBuilder<LocalDate>(
+          child: ValueListenableBuilder<LocalDate>(
               valueListenable: controller.dateListenable,
-              builder: (context, date, _) =>
-                  WeekIndicator(weekYearRule.getWeekOfWeekYear(date)),
-            ),
-          ),
+              builder: (context, date, _) {
+                return weekIndicatorBuilder?.call(context, date) ??
+                    Center(
+                        child: WeekIndicator(
+                            weekYearRule.getWeekOfWeekYear(date)));
+              }),
         ),
         Expanded(
           child: Column(
@@ -47,7 +52,10 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
             children: <Widget>[
               SizedBox(
                 height: context.timetableTheme?.totalDateIndicatorHeight ?? 72,
-                child: MultiDateHeader(controller: controller),
+                child: MultiDateHeader(
+                  controller: controller,
+                  builder: dayHeaderBuilder,
+                ),
               ),
               AllDayEvents<E>(
                 controller: controller,

--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -15,7 +15,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
     @required this.controller,
     @required this.allDayEventBuilder,
     this.onEventBackgroundTap,
-    this.weekIndicatorBuilder,
+    this.leadingHeaderBuilder,
     this.dateHeaderBuilder,
   })  : assert(controller != null),
         assert(allDayEventBuilder != null),
@@ -24,7 +24,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
   final TimetableController<E> controller;
   final AllDayEventBuilder<E> allDayEventBuilder;
   final OnEventBackgroundTapCallback onEventBackgroundTap;
-  final HeaderWidgetBuilder weekIndicatorBuilder;
+  final HeaderWidgetBuilder leadingHeaderBuilder;
   final HeaderWidgetBuilder dateHeaderBuilder;
 
   @override
@@ -40,7 +40,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
           child: ValueListenableBuilder<LocalDate>(
             valueListenable: controller.dateListenable,
             builder: (context, date, _) {
-              final customHeader = weekIndicatorBuilder?.call(context, date);
+              final customHeader = leadingHeaderBuilder?.call(context, date);
               if (customHeader != null) {
                 return customHeader;
               }

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -18,7 +18,7 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
 
 /// Signature for [Timetable.weekIndicatorBuilder] and
 /// [Timetable.weekIndicatorBuilder].
-typedef HeaderBuilder = Widget Function(
+typedef HeaderWidgetBuilder = Widget Function(
   BuildContext context,
   LocalDate date
 );
@@ -65,13 +65,13 @@ class Timetable<E extends Event> extends StatelessWidget {
   ///
   /// If it's not provided, or the builder returns `null`, a week indicator
   /// will be shown.
-  final HeaderBuilder weekIndicatorBuilder;
+  final HeaderWidgetBuilder weekIndicatorBuilder;
 
   /// Custom builder for header of a single date.
   ///
   /// If it's not provided, or the builder returns `null`, the day of week and
   /// day of month will be shown.
-  final HeaderBuilder dayHeaderBuilder;
+  final HeaderWidgetBuilder dayHeaderBuilder;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -67,10 +67,10 @@ class Timetable<E extends Event> extends StatelessWidget {
   /// will be shown.
   final HeaderBuilder weekIndicatorBuilder;
 
-  /// Builder for Day header.
+  /// Custom builder for header of a single date.
   ///
-  /// If it's not provided, or builder returns `null`,
-  /// default `DateHeader` widget will be used
+  /// If it's not provided, or the builder returns `null`, the day of week and
+  /// day of month will be shown.
   final HeaderBuilder dayHeaderBuilder;
 
   @override

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -61,10 +61,10 @@ class Timetable<E extends Event> extends StatelessWidget {
   /// out.
   final OnEventBackgroundTapCallback onEventBackgroundTap;
 
-  /// Builder for Week Indicator area.
+  /// Custom builder for the left area of the header.
   ///
-  /// If it's not provided, or builder returns `null`,
-  /// default `WeekIndicator` widget will be used
+  /// If it's not provided, or the builder returns `null`, a week indicator
+  /// will be shown.
   final HeaderBuilder weekIndicatorBuilder;
 
   /// Builder for Day header.

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -17,7 +17,7 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
 );
 
 /// Signature for [Timetable.weekIndicatorBuilder] and
-/// [Timetable.weekIndicatorBuilder].
+/// [Timetable.dateHeaderBuilder].
 typedef HeaderWidgetBuilder = Widget Function(
   BuildContext context,
   LocalDate date
@@ -42,7 +42,7 @@ class Timetable<E extends Event> extends StatelessWidget {
     this.allDayEventBuilder,
     this.onEventBackgroundTap,
     this.theme,
-    this.dayHeaderBuilder,
+    this.dateHeaderBuilder,
     this.weekIndicatorBuilder,
   })  : assert(controller != null),
         assert(eventBuilder != null),
@@ -71,7 +71,7 @@ class Timetable<E extends Event> extends StatelessWidget {
   ///
   /// If it's not provided, or the builder returns `null`, the day of week and
   /// day of month will be shown.
-  final HeaderWidgetBuilder dayHeaderBuilder;
+  final HeaderWidgetBuilder dateHeaderBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -81,7 +81,7 @@ class Timetable<E extends Event> extends StatelessWidget {
           controller: controller,
           onEventBackgroundTap: onEventBackgroundTap,
           weekIndicatorBuilder: weekIndicatorBuilder,
-          dayHeaderBuilder: dayHeaderBuilder,
+          dateHeaderBuilder: dateHeaderBuilder,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),
         ),

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -15,6 +15,9 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
   E event,
   AllDayEventLayoutInfo info,
 );
+
+/// Signature for [Timetable.weekIndicatorBuilder] and
+/// [Timetable.weekIndicatorBuilder] params
 typedef HeaderBuilder = Widget Function(
   BuildContext context,
   LocalDate date
@@ -61,13 +64,13 @@ class Timetable<E extends Event> extends StatelessWidget {
   /// Builder for Week Indicator area.
   ///
   /// If it's not provided, or builder returns `null`,
-  /// default [WeekIndicator] widget will be used
+  /// default `WeekIndicator` widget will be used
   final HeaderBuilder weekIndicatorBuilder;
 
   /// Builder for Day header.
   ///
   /// If it's not provided, or builder returns `null`,
-  /// default [DateHeader] widget will be used
+  /// default `DateHeader` widget will be used
   final HeaderBuilder dayHeaderBuilder;
 
   @override

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -16,7 +16,7 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
   AllDayEventLayoutInfo info,
 );
 
-/// Signature for [Timetable.weekIndicatorBuilder] and
+/// Signature for [Timetable.leadingHeaderBuilder] and
 /// [Timetable.dateHeaderBuilder].
 typedef HeaderWidgetBuilder = Widget Function(
   BuildContext context,
@@ -43,7 +43,7 @@ class Timetable<E extends Event> extends StatelessWidget {
     this.onEventBackgroundTap,
     this.theme,
     this.dateHeaderBuilder,
-    this.weekIndicatorBuilder,
+    this.leadingHeaderBuilder,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);
@@ -65,7 +65,7 @@ class Timetable<E extends Event> extends StatelessWidget {
   ///
   /// If it's not provided, or the builder returns `null`, a week indicator
   /// will be shown.
-  final HeaderWidgetBuilder weekIndicatorBuilder;
+  final HeaderWidgetBuilder leadingHeaderBuilder;
 
   /// Custom builder for header of a single date.
   ///
@@ -80,7 +80,7 @@ class Timetable<E extends Event> extends StatelessWidget {
         TimetableHeader<E>(
           controller: controller,
           onEventBackgroundTap: onEventBackgroundTap,
-          weekIndicatorBuilder: weekIndicatorBuilder,
+          leadingHeaderBuilder: leadingHeaderBuilder,
           dateHeaderBuilder: dateHeaderBuilder,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -17,7 +17,7 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
 );
 
 /// Signature for [Timetable.weekIndicatorBuilder] and
-/// [Timetable.weekIndicatorBuilder] params
+/// [Timetable.weekIndicatorBuilder].
 typedef HeaderBuilder = Widget Function(
   BuildContext context,
   LocalDate date

--- a/lib/src/timetable.dart
+++ b/lib/src/timetable.dart
@@ -15,6 +15,10 @@ typedef AllDayEventBuilder<E extends Event> = Widget Function(
   E event,
   AllDayEventLayoutInfo info,
 );
+typedef HeaderBuilder = Widget Function(
+  BuildContext context,
+  LocalDate date
+);
 
 /// Signature for [Timetable.onEventBackgroundTap].
 ///
@@ -35,6 +39,8 @@ class Timetable<E extends Event> extends StatelessWidget {
     this.allDayEventBuilder,
     this.onEventBackgroundTap,
     this.theme,
+    this.dayHeaderBuilder,
+    this.weekIndicatorBuilder,
   })  : assert(controller != null),
         assert(eventBuilder != null),
         super(key: key);
@@ -52,6 +58,18 @@ class Timetable<E extends Event> extends StatelessWidget {
   /// out.
   final OnEventBackgroundTapCallback onEventBackgroundTap;
 
+  /// Builder for Week Indicator area.
+  ///
+  /// If it's not provided, or builder returns `null`,
+  /// default [WeekIndicator] widget will be used
+  final HeaderBuilder weekIndicatorBuilder;
+
+  /// Builder for Day header.
+  ///
+  /// If it's not provided, or builder returns `null`,
+  /// default [DateHeader] widget will be used
+  final HeaderBuilder dayHeaderBuilder;
+
   @override
   Widget build(BuildContext context) {
     Widget child = Column(
@@ -59,6 +77,8 @@ class Timetable<E extends Event> extends StatelessWidget {
         TimetableHeader<E>(
           controller: controller,
           onEventBackgroundTap: onEventBackgroundTap,
+          weekIndicatorBuilder: weekIndicatorBuilder,
+          dayHeaderBuilder: dayHeaderBuilder,
           allDayEventBuilder:
               allDayEventBuilder ?? (_, event, __) => eventBuilder(event),
         ),


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
**Closes: #27**

<!-- Please summarize your changes: -->

Added 2 builders for header:
`weekIndicatorBuilder` and `dayHeaderBuilder`

Both builder signed with same typedef, which is

```dart
typedef HeaderBuilder = Widget Function(
  BuildContext context,
  LocalDate date
);
```

Both builders are optional. If builder is not provided or it returns `null` - default (current one) header widgets will be used.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
