### PR TITLE
Fix #47 - Negative width on all day event

### DIFF
--- a/lib/src/header/all_day_events.dart
+++ b/lib/src/header/all_day_events.dart
@@ -398,7 +398,7 @@ class _EventsLayout<E extends Event> extends RenderBox
           ((endDate.epochDay + 1 - page) * dateWidth).coerceAtMost(size.width);
 
       child.layout(BoxConstraints.tightFor(
-        width: right - left,
+        width: abs(right - left),
         height: eventHeight,
       ));
 

--- a/lib/src/header/all_day_events.dart
+++ b/lib/src/header/all_day_events.dart
@@ -398,7 +398,7 @@ class _EventsLayout<E extends Event> extends RenderBox
           ((endDate.epochDay + 1 - page) * dateWidth).coerceAtMost(size.width);
 
       child.layout(BoxConstraints.tightFor(
-        width: abs(right - left),
+        width: (right - left).abs(),
         height: eventHeight,
       ));
 


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
**Closes: #47**

<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
This is a very simple fix, just adding an `abs` to prevent a negative value. Let me know if I should add anything else.



### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


<!-- Add this section if you need it.
### Screenshots

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
