### PR TITLE
Compatibility with Flutter v1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   JAVA_VERSION: 12.x
-  FLUTTER_CHANNEL: stable
-  FLUTTER_VERSION: 1.17.x
+  FLUTTER_CHANNEL: beta
+  FLUTTER_VERSION: 1.23.0-13.0.pre
 
 jobs:
   install:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 env:
   JAVA_VERSION: 12.x
   FLUTTER_CHANNEL: beta
-  FLUTTER_VERSION: 1.23.0-13.0.pre
 
 jobs:
   install:
@@ -119,7 +118,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v1
         with:
-          channel: "stable"
+          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Checkout source
         uses: actions/download-artifact@v2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -132,4 +132,4 @@ packages:
     version: "2.1.0-nullsafety.3"
 sdks:
   dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
-  flutter: ">=1.17.0"
+  flutter: ">=1.23.0-13.0.pre"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   time_machine: ^0.9.12
 
 dependency_overrides:
+  # https://github.com/Dana-Ferguson/time_machine/issues/44
   meta: 1.3.0-nullsafety.3
 
 flutter:

--- a/lib/src/utils/scrolling.dart
+++ b/lib/src/utils/scrolling.dart
@@ -196,9 +196,10 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
 
   @override
   bool applyViewportDimension(double viewportDimension) {
-    final oldViewportDimension = this.viewportDimension;
+    final oldViewportDimension =
+        hasViewportDimension ? this.viewportDimension : null;
     final result = super.applyViewportDimension(viewportDimension);
-    final oldPixels = pixels;
+    final oldPixels = hasPixels ? pixels : null;
     final page = (oldPixels == null || oldViewportDimension == 0.0)
         ? initialPage
         : oldPixels /

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,3 +23,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.9.4
+
+dependency_overrides:
+  # https://github.com/Dana-Ferguson/time_machine/issues/44
+  meta: 1.3.0-nullsafety.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/JonasWanke/timetable
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.23.0-13.0.pre"
 
 dependencies:
   flutter:


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
**Closes: #55**

<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
Flutter v1.23.0-13.0.pre changed some of `ScrollPosition`'s getters to be non-null. As the underlying values can still be null, we now have to first check the `hasFoo`-getters before accessing `foo`-values, similar to flutter/flutter#66250. As the `hasFoo`-getters are new, this fix also changes the lower Flutter SDK bound of timetable.


<!-- Add this section if you need it.
### Screenshots

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
