### PR TITLE
feat: Multiple language support and 24-hour format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Some date/time-related parameters also have special suffixes:
 * `timeOfDay`: A `Duration` between zero and 24 hours.
 * `dayOfWeek`: An `int` between one and seven ([`DateTime.monday`](https://api.flutter.dev/flutter/dart-core/DateTime/monday-constant.html) through [`DateTime.sunday`](https://api.flutter.dev/flutter/dart-core/DateTime/sunday-constant.html)).
 
-Timetable currently offers localizations for English and German.
+Timetable currently offers localizations for English, German, Japanese and Chinese.
 Even if you're just supporting English in your app, you have to add Timetable's localization delegate to your `MaterialApp`/`CupertinoApp`/`WidgetsApp`:
 
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -117,7 +117,7 @@ class _TimetableExampleState extends State<TimetableExample>
         // timeIndicatorStyleProvider: (time) => TimeIndicatorStyle(
         //   context,
         //   time,
-        //   use24hour: true,
+        //   alwaysUse24HourFormat: false,
         // ),
       ),
     );
@@ -144,7 +144,7 @@ class _TimetableExampleState extends State<TimetableExample>
         setState(() => _draggedEvents.removeWhere((it) => it.id == event.id));
         _showSnackBar('Dragged event to $dateTime.');
       },
-      onDragCanceled: print,
+      onDragCanceled: (isMoved) => _showSnackBar('Your finger moved: $isMoved'),
       child: BasicEventWidget(
         event,
         onTap: () => _showSnackBar('Part-day event $event tapped'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -144,6 +144,7 @@ class _TimetableExampleState extends State<TimetableExample>
         setState(() => _draggedEvents.removeWhere((it) => it.id == event.id));
         _showSnackBar('Dragged event to $dateTime.');
       },
+      onDragCanceled: print,
       child: BasicEventWidget(
         event,
         onTap: () => _showSnackBar('Part-day event $event tapped'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -114,6 +114,11 @@ class _TimetableExampleState extends State<TimetableExample>
         //   lineColor: Colors.green,
         //   shape: TriangleNowIndicatorShape(color: Colors.green),
         // ),
+        // timeIndicatorStyleProvider: (time) => TimeIndicatorStyle(
+        //   context,
+        //   time,
+        //   use24hour: true,
+        // ),
       ),
     );
   }

--- a/example/lib/utils.dart
+++ b/example/lib/utils.dart
@@ -7,7 +7,13 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:timetable/timetable.dart';
 
 final _mediaOverrideState = ValueNotifier(MediaOverrideState());
-final _supportedLocales = [const Locale('de'), const Locale('en')];
+final _supportedLocales = [
+  const Locale('de'),
+  const Locale('en'),
+  const Locale('ja'),
+  const Locale('zh', 'CN'),
+  const Locale('zh', 'TW'),
+];
 
 void initDebugOverlay() {
   // https://pub.dev/packages/debug_overlay

--- a/lib/src/components/multi_date_content.dart
+++ b/lib/src/components/multi_date_content.dart
@@ -151,7 +151,7 @@ class _PartDayDraggableEventState extends State<PartDayDraggableEvent> {
               widget.onDragUpdate!(_lastDragDateTime!);
             }
           : null,
-      onDragEnd: widget.onDragEnd != null
+      onDragEnd: widget.onDragEnd != null && _lastDragDateTime != null
           ? (details) {
               widget.onDragEnd!(_lastDragDateTime!);
               _lastDragDateTime = null;

--- a/lib/src/components/multi_date_content.dart
+++ b/lib/src/components/multi_date_content.dart
@@ -151,21 +151,21 @@ class _PartDayDraggableEventState extends State<PartDayDraggableEvent> {
       data: _DragData(),
       maxSimultaneousDrags: 1,
       onDragStarted: widget.onDragStart,
-      onDragUpdate: widget.onDragUpdate != null
-          ? (details) {
-              _lastDragDateTime =
-                  _DragInfos.resolveOffset(context, details.globalPosition);
-              widget.onDragUpdate!(_lastDragDateTime!);
-              _isMoved = true;
-            }
-          : (_) => _isMoved = true,
-      onDragEnd: widget.onDragEnd != null
-          ? (details) {
-              widget.onDragEnd!(_lastDragDateTime);
-              _lastDragDateTime = null;
-              _isMoved = false;
-            }
-          : (_) => _isMoved = false,
+      onDragUpdate: (details) {
+        if (widget.onDragUpdate != null) {
+          _lastDragDateTime =
+              _DragInfos.resolveOffset(context, details.globalPosition);
+          widget.onDragUpdate!(_lastDragDateTime!);
+        }
+        _isMoved = true;
+      },
+      onDragEnd: (details) {
+        if (widget.onDragEnd != null) {
+          widget.onDragEnd!(_lastDragDateTime);
+          _lastDragDateTime = null;
+        }
+        _isMoved = false;
+      },
       onDraggableCanceled: widget.onDragCanceled != null
           ? (_, __) => widget.onDragCanceled!(_isMoved)
           : null,

--- a/lib/src/components/multi_date_content.dart
+++ b/lib/src/components/multi_date_content.dart
@@ -158,7 +158,7 @@ class _PartDayDraggableEventState extends State<PartDayDraggableEvent> {
               widget.onDragUpdate!(_lastDragDateTime!);
               _isMoved = true;
             }
-          : null,
+          : (_) => _isMoved = true,
       onDragEnd: widget.onDragEnd != null
           ? (details) {
               widget.onDragEnd!(_lastDragDateTime);

--- a/lib/src/components/multi_date_content.dart
+++ b/lib/src/components/multi_date_content.dart
@@ -163,8 +163,9 @@ class _PartDayDraggableEventState extends State<PartDayDraggableEvent> {
           ? (details) {
               widget.onDragEnd!(_lastDragDateTime);
               _lastDragDateTime = null;
+              _isMoved = false;
             }
-          : null,
+          : (_) => _isMoved = false,
       onDraggableCanceled: widget.onDragCanceled != null
           ? (_, __) => widget.onDragCanceled!(_isMoved)
           : null,

--- a/lib/src/components/multi_date_content.dart
+++ b/lib/src/components/multi_date_content.dart
@@ -114,6 +114,7 @@ class PartDayDraggableEvent extends StatefulWidget {
     this.onDragStart,
     this.onDragUpdate,
     this.onDragEnd,
+    this.onDragCanceled,
     required this.child,
     Widget? childWhileDragging,
   }) : childWhileDragging =
@@ -128,6 +129,11 @@ class PartDayDraggableEvent extends StatefulWidget {
   /// their finger at all.
   final void Function(DateTime?)? onDragEnd;
 
+  /// Called when a drag gesture is canceled.
+  ///
+  /// The [bool] indicates whether the user moved their finger or not.
+  final void Function(bool isMoved)? onDragCanceled;
+
   final Widget child;
   final Widget childWhileDragging;
 
@@ -137,6 +143,7 @@ class PartDayDraggableEvent extends StatefulWidget {
 
 class _PartDayDraggableEventState extends State<PartDayDraggableEvent> {
   DateTime? _lastDragDateTime;
+  var _isMoved = false;
 
   @override
   Widget build(BuildContext context) {
@@ -149,13 +156,17 @@ class _PartDayDraggableEventState extends State<PartDayDraggableEvent> {
               _lastDragDateTime =
                   _DragInfos.resolveOffset(context, details.globalPosition);
               widget.onDragUpdate!(_lastDragDateTime!);
+              _isMoved = true;
             }
           : null,
-      onDragEnd: widget.onDragEnd != null && _lastDragDateTime != null
+      onDragEnd: widget.onDragEnd != null
           ? (details) {
-              widget.onDragEnd!(_lastDragDateTime!);
+              widget.onDragEnd!(_lastDragDateTime);
               _lastDragDateTime = null;
             }
+          : null,
+      onDraggableCanceled: widget.onDragCanceled != null
+          ? (_, __) => widget.onDragCanceled!(_isMoved)
           : null,
       child: widget.child,
       childWhenDragging: widget.childWhileDragging,

--- a/lib/src/components/time_indicator.dart
+++ b/lib/src/components/time_indicator.dart
@@ -68,7 +68,7 @@ class TimeIndicatorStyle {
     Duration time, {
     TextStyle? textStyle,
     String? label,
-    bool use24hour = false,
+    bool alwaysUse24HourFormat = true,
   }) {
     assert(time.isValidTimetableTimeOfDay);
 
@@ -88,7 +88,7 @@ class TimeIndicatorStyle {
       label: label ??
           () {
             context.dependOnTimetableLocalizations();
-            return use24hour
+            return alwaysUse24HourFormat
                 ? TimeIndicator.formatHour24(time)
                 : TimeIndicator.formatHour(time);
           }(),

--- a/lib/src/components/time_indicator.dart
+++ b/lib/src/components/time_indicator.dart
@@ -68,6 +68,7 @@ class TimeIndicatorStyle {
     Duration time, {
     TextStyle? textStyle,
     String? label,
+    bool use24hour = false,
   }) {
     assert(time.isValidTimetableTimeOfDay);
 
@@ -87,7 +88,9 @@ class TimeIndicatorStyle {
       label: label ??
           () {
             context.dependOnTimetableLocalizations();
-            return TimeIndicator.formatHour(time);
+            return use24hour
+                ? TimeIndicator.formatHour24(time)
+                : TimeIndicator.formatHour(time);
           }(),
     );
   }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -9,6 +9,9 @@ import 'week.dart';
 ///
 /// * `de` –German
 /// * `en` – English
+/// * `ja` – Japanese
+/// * `zh_CN` – Chinese(Simplified)
+/// * `zh_TW` – Chinese(Traditional)
 ///
 /// By default, this delegate also configures [Intl] whenever Flutter's locale
 /// changes. This behavior can be disabled via [setIntlLocale].
@@ -41,6 +44,13 @@ class TimetableLocalizationsDelegate
         return const TimetableLocalizationDe();
       case 'en':
         return const TimetableLocalizationEn();
+      case 'ja':
+        return const TimetableLocalizationJa();
+      case 'zh':
+        if (locale.countryCode?.toLowerCase() == 'tw') {
+          return const TimetableLocalizationZhTw();
+        }
+        return const TimetableLocalizationZhCn();
       default:
         return null;
     }
@@ -137,6 +147,60 @@ class TimetableLocalizationEn extends TimetableLocalizations {
       weekOfYear(week),
       'Week ${week.weekOfYear}',
       'W ${week.weekOfYear}',
+      '${week.weekOfYear}',
+    ];
+  }
+
+  @override
+  String weekOfYear(Week week) =>
+      'Week ${week.weekOfYear}, ${week.weekBasedYear}';
+}
+
+class TimetableLocalizationJa extends TimetableLocalizations {
+  const TimetableLocalizationJa();
+
+  @override
+  List<String> weekLabels(Week week) {
+    return [
+      weekOfYear(week),
+      '第${week.weekOfYear}週',
+      '${week.weekOfYear}週',
+      '${week.weekOfYear}',
+    ];
+  }
+
+  @override
+  String weekOfYear(Week week) =>
+      'Week ${week.weekOfYear}, ${week.weekBasedYear}';
+}
+
+class TimetableLocalizationZhCn extends TimetableLocalizations {
+  const TimetableLocalizationZhCn();
+
+  @override
+  List<String> weekLabels(Week week) {
+    return [
+      weekOfYear(week),
+      '第${week.weekOfYear}周',
+      '${week.weekOfYear}周',
+      '${week.weekOfYear}',
+    ];
+  }
+
+  @override
+  String weekOfYear(Week week) =>
+      'Week ${week.weekOfYear}, ${week.weekBasedYear}';
+}
+
+class TimetableLocalizationZhTw extends TimetableLocalizations {
+  const TimetableLocalizationZhTw();
+
+  @override
+  List<String> weekLabels(Week week) {
+    return [
+      weekOfYear(week),
+      '第${week.weekOfYear}週',
+      '${week.weekOfYear}週',
       '${week.weekOfYear}',
     ];
   }


### PR DESCRIPTION
Closes: #61 

- Add language support for Chinese/Japanese
- Add a theming parameter for toggle 12-hour/24-hour format
- Remove unnecessary null checks to avoid app crashes
- Add a parameter to handle event happens when ther user canceled drag gesture
This change will fix an issue: user cannot remove the created time overlay if drag gesture canceled without any movement.

### Checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
