### PR TITLE
Support Equatable

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   black_hole_flutter:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: dartx
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   data_size:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   device_info_plus_linux:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: device_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -145,7 +145,7 @@ packages:
       name: flutter_layout_grid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -225,14 +225,14 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.2"
   package_info_plus_linux:
     dependency: transitive
     description:
       name: package_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   package_info_plus_macos:
     dependency: transitive
     description:
@@ -253,14 +253,14 @@ packages:
       name: package_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   package_info_plus_windows:
     dependency: transitive
     description:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -288,7 +288,7 @@ packages:
       name: sensors_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   sensors_plus_platform_interface:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: shake
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -321,7 +321,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -391,7 +391,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.1"
 sdks:
   dart: ">=2.15.0 <3.0.0"
   flutter: ">=2.8.0"

--- a/lib/src/components/date_content.dart
+++ b/lib/src/components/date_content.dart
@@ -30,10 +30,6 @@ class DateContent<E extends Event> extends StatelessWidget {
           events.every((e) => e.interval.intersects(date.fullDayInterval)),
           'All events must intersect the given date',
         ),
-        assert(
-          events.toSet().length == events.length,
-          'Events may not contain duplicates',
-        ),
         events = events.sortedByStartLength(),
         super(key: key);
 

--- a/lib/src/components/date_events.dart
+++ b/lib/src/components/date_events.dart
@@ -28,10 +28,6 @@ class DateEvents<E extends Event> extends StatelessWidget {
           events.every((e) => e.interval.intersects(date.fullDayInterval)),
           'All events must intersect the given date',
         ),
-        assert(
-          events.toSet().length == events.length,
-          'Events may not contain duplicates',
-        ),
         events = events.sortedByStartLength(),
         super(key: key);
 

--- a/lib/src/event/event.dart
+++ b/lib/src/event/event.dart
@@ -1,7 +1,4 @@
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart' hide Interval;
 
 import '../utils.dart';
 import 'basic.dart';
@@ -24,17 +21,6 @@ abstract class Event with Diagnosticable {
   final DateTime end;
 
   bool get isAllDay => end.difference(start).inDays >= 1;
-
-  @override
-  bool operator ==(dynamic other) {
-    return other is Event &&
-        runtimeType == other.runtimeType &&
-        start == other.start &&
-        end == other.end;
-  }
-
-  @override
-  int get hashCode => hashValues(runtimeType, start, end);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/event/provider.dart
+++ b/lib/src/event/provider.dart
@@ -64,11 +64,6 @@ extension EventProviderTimetable<E extends Event> on EventProvider<E> {
         return true;
       }());
 
-      assert(
-        events.toSet().length == events.length,
-        'Events may not contain duplicates.',
-      );
-
       return events;
     };
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   dartx: ^1.0.0
   flutter:
     sdk: flutter
-  flutter_layout_grid: ^1.0.1
+  flutter_layout_grid: ^2.0.0
   intl: ^0.17.0
   meta: ^1.3.0
   tuple: ^2.0.0


### PR DESCRIPTION
This PR mainly adds support for equatable in `Event`s. Support for it could be added in various other places as well, but this fixes an important bug in my application:
Some users get the error message `Events may not contain duplicates.`, which is not entirely correct in my case.
The events I was adding are different in regards to the title and so on, but their `start` and `end` entries match which are the only entries that are being compared in `timetable`.
By using the `equatable` package, one can simply compare additional entries in their custom `Event`s by adding the following override:
```dart
  @override
  List<Object> get props => super.props..addAll([fieldToCompare1, fieldToCompare2]);
```
It might be worth to consider such a widely-utilized package in this case. Thus, this PR adds compatability for it (in this particular case! There could be many other cases where it might make sense to migrate to it as well).

 - Updated dependencies and Android SDK entries
 - Migrated to Flutter embedding v2 (removes the warning when running the example)
 - Add support for equatable in events