### PR TITLE
Update to Flutter 3

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   dart_date:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -145,7 +145,7 @@ packages:
       name: flutter_layout_grid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -190,7 +190,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   list_diff:
     dependency: transitive
     description:
@@ -211,7 +211,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -267,7 +267,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1+1"
+    version: "3.1.0"
   sensors_plus:
     dependency: transitive
     description:
@@ -335,7 +335,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
@@ -377,21 +377,21 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.1"
+    version: "2.6.1"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
-  flutter: ">=2.8.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=2.13.0-0.4.pre"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: A simple example app for the timetable package
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.8.0'
+  sdk: '>=2.17.0-266.8.beta <3.0.0'
+  flutter: '>=2.13.0-0.4.pre'
 
 dependencies:
   debug_overlay: ^0.1.1

--- a/lib/src/callbacks.dart
+++ b/lib/src/callbacks.dart
@@ -100,8 +100,8 @@ class TimetableCallbacks {
 class DefaultTimetableCallbacks extends InheritedWidget {
   const DefaultTimetableCallbacks({
     required this.callbacks,
-    required Widget child,
-  }) : super(child: child);
+    required super.child,
+  });
 
   final TimetableCallbacks callbacks;
 

--- a/lib/src/components/date_content.dart
+++ b/lib/src/components/date_content.dart
@@ -20,7 +20,7 @@ import 'time_overlays.dart';
 ///   Timetable widgets.
 class DateContent<E extends Event> extends StatelessWidget {
   DateContent({
-    Key? key,
+    super.key,
     required this.date,
     required List<E> events,
     this.overlays = const [],
@@ -30,8 +30,7 @@ class DateContent<E extends Event> extends StatelessWidget {
           events.every((e) => e.interval.intersects(date.fullDayInterval)),
           'All events must intersect the given date',
         ),
-        events = events.sortedByStartLength(),
-        super(key: key);
+        events = events.sortedByStartLength();
 
   final DateTime date;
 

--- a/lib/src/components/date_dividers.dart
+++ b/lib/src/components/date_dividers.dart
@@ -4,7 +4,7 @@ import '../config.dart';
 import '../date/controller.dart';
 import '../theme.dart';
 
-/// A widget that displays vertical dividers betweeen dates.
+/// A widget that displays vertical dividers between dates.
 ///
 /// A [DefaultDateController] must be above in the widget tree.
 ///
@@ -15,10 +15,10 @@ import '../theme.dart';
 ///   descendant Timetable widgets.
 class DateDividers extends StatelessWidget {
   const DateDividers({
-    Key? key,
+    super.key,
     this.style,
     this.child,
-  }) : super(key: key);
+  });
 
   final DateDividersStyle? style;
   final Widget? child;

--- a/lib/src/components/date_events.dart
+++ b/lib/src/components/date_events.dart
@@ -18,7 +18,7 @@ import '../utils.dart';
 ///   descendant Timetable widgets.
 class DateEvents<E extends Event> extends StatelessWidget {
   DateEvents({
-    Key? key,
+    super.key,
     required this.date,
     required List<E> events,
     this.eventBuilder,
@@ -28,8 +28,7 @@ class DateEvents<E extends Event> extends StatelessWidget {
           events.every((e) => e.interval.intersects(date.fullDayInterval)),
           'All events must intersect the given date',
         ),
-        events = events.sortedByStartLength(),
-        super(key: key);
+        events = events.sortedByStartLength();
 
   final DateTime date;
   final List<E> events;

--- a/lib/src/components/date_header.dart
+++ b/lib/src/components/date_header.dart
@@ -24,11 +24,10 @@ import 'weekday_indicator.dart';
 class DateHeader extends StatelessWidget {
   DateHeader(
     this.date, {
-    Key? key,
+    super.key,
     this.onTap,
     this.style,
-  })  : assert(date.isValidTimetableDate),
-        super(key: key);
+  }) : assert(date.isValidTimetableDate);
 
   final DateTime date;
   final VoidCallback? onTap;

--- a/lib/src/components/date_indicator.dart
+++ b/lib/src/components/date_indicator.dart
@@ -23,11 +23,10 @@ import '../utils.dart';
 class DateIndicator extends StatelessWidget {
   DateIndicator(
     this.date, {
-    Key? key,
+    super.key,
     this.onTap,
     this.style,
-  })  : assert(date.isValidTimetableDate),
-        super(key: key);
+  }) : assert(date.isValidTimetableDate);
 
   final DateTime date;
   final VoidCallback? onTap;

--- a/lib/src/components/hour_dividers.dart
+++ b/lib/src/components/hour_dividers.dart
@@ -4,7 +4,7 @@ import '../config.dart';
 import '../theme.dart';
 import '../utils.dart';
 
-/// A widget that displays horizontal dividers betweeen hours of a day.
+/// A widget that displays horizontal dividers between hours of a day.
 ///
 /// See also:
 ///
@@ -13,10 +13,10 @@ import '../utils.dart';
 ///   descendant Timetable widgets.
 class HourDividers extends StatelessWidget {
   const HourDividers({
-    Key? key,
+    super.key,
     this.style,
     this.child,
-  }) : super(key: key);
+  });
 
   final HourDividersStyle? style;
   final Widget? child;

--- a/lib/src/components/month_indicator.dart
+++ b/lib/src/components/month_indicator.dart
@@ -18,10 +18,9 @@ import '../utils.dart';
 class MonthIndicator extends StatelessWidget {
   MonthIndicator(
     this.month, {
-    Key? key,
+    super.key,
     this.style,
-  })  : assert(month.isValidTimetableMonth),
-        super(key: key);
+  }) : assert(month.isValidTimetableMonth);
   static Widget forController(DateController? controller, {Key? key}) =>
       _MonthIndicatorForController(controller, key: key);
 
@@ -91,9 +90,9 @@ class MonthIndicatorStyle {
 class _MonthIndicatorForController extends StatelessWidget {
   const _MonthIndicatorForController(
     this.controller, {
-    Key? key,
+    super.key,
     this.style,
-  }) : super(key: key);
+  });
 
   final DateController? controller;
   final MonthIndicatorStyle? style;

--- a/lib/src/components/multi_date_content.dart
+++ b/lib/src/components/multi_date_content.dart
@@ -31,7 +31,7 @@ import 'now_indicator.dart';
 ///   [DatePageView], and [DateContent], which are used internally by this
 ///   widget and can be styled.
 class MultiDateContent<E extends Event> extends StatelessWidget {
-  const MultiDateContent({Key? key}) : super(key: key);
+  const MultiDateContent({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -76,8 +76,8 @@ class _DragInfos extends InheritedWidget {
     required this.context,
     required this.dateController,
     required this.size,
-    required Widget child,
-  }) : super(child: child);
+    required super.child,
+  });
 
   // Storing the context feels wrong but I haven't found a different way to
   // transform global coordinates back to local ones in this context.
@@ -125,7 +125,7 @@ class PartDayDraggableEvent extends StatefulWidget {
 
   /// Called when a drag gesture is ended.
   ///
-  /// The [DateTime] is `null` when the user long tapps but then doesn't move
+  /// The [DateTime] is `null` when the user long taps but then doesn't move
   /// their finger at all.
   final void Function(DateTime?)? onDragEnd;
 

--- a/lib/src/components/multi_date_event_header.dart
+++ b/lib/src/components/multi_date_event_header.dart
@@ -35,10 +35,10 @@ import '../utils.dart';
 ///   Timetable widgets.
 class MultiDateEventHeader<E extends Event> extends StatelessWidget {
   const MultiDateEventHeader({
-    Key? key,
+    super.key,
     this.onBackgroundTap,
     this.style,
-  }) : super(key: key);
+  });
 
   final DateTapCallback? onBackgroundTap;
   final MultiDateEventHeaderStyle? style;
@@ -180,10 +180,10 @@ class MultiDateEventHeaderStyle {
 class _EventParentDataWidget<E extends Event>
     extends ParentDataWidget<_EventParentData<E>> {
   const _EventParentDataWidget({
-    Key? key,
+    super.key,
     required this.event,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   final E event;
 
@@ -207,8 +207,8 @@ class _EventsWidget<E extends Event> extends MultiChildRenderObjectWidget {
   _EventsWidget({
     required this.pageValue,
     required this.eventHeight,
-    required List<_EventParentDataWidget<E>> children,
-  }) : super(children: children);
+    required super.children,
+  });
 
   final DatePageValue pageValue;
   final double eventHeight;

--- a/lib/src/components/now_indicator.dart
+++ b/lib/src/components/now_indicator.dart
@@ -23,10 +23,10 @@ import '../utils.dart';
 ///   descendant Timetable widgets.
 class NowIndicator extends StatelessWidget {
   const NowIndicator({
-    Key? key,
+    super.key,
     this.style,
     this.child,
-  }) : super(key: key);
+  });
 
   final NowIndicatorStyle? style;
   final Widget? child;

--- a/lib/src/components/time_indicator.dart
+++ b/lib/src/components/time_indicator.dart
@@ -21,11 +21,10 @@ import 'time_indicators.dart';
 ///   descendant Timetable widgets.
 class TimeIndicator extends StatelessWidget {
   TimeIndicator({
-    Key? key,
+    super.key,
     required this.time,
     this.style,
-  })  : assert(time.isValidTimetableTimeOfDay),
-        super(key: key);
+  }) : assert(time.isValidTimetableTimeOfDay);
 
   static String formatHour(Duration time) => _format(DateFormat.j(), time);
   static String formatHourMinute(Duration time) =>

--- a/lib/src/components/time_indicators.dart
+++ b/lib/src/components/time_indicators.dart
@@ -19,7 +19,7 @@ import 'time_indicator.dart';
 /// * [TimeIndicator], which is usually used inside a [TimeIndicatorsChild] to
 ///   display a label.
 class TimeIndicators extends StatelessWidget {
-  const TimeIndicators({Key? key, required this.children}) : super(key: key);
+  const TimeIndicators({super.key, required this.children});
 
   factory TimeIndicators.hours({
     Key? key,
@@ -129,8 +129,7 @@ class TimeIndicators extends StatelessWidget {
 }
 
 class _TimeIndicators extends MultiChildRenderObjectWidget {
-  _TimeIndicators({required List<TimeIndicatorsChild> children})
-      : super(children: children);
+  _TimeIndicators({required super.children});
 
   @override
   RenderObject createRenderObject(BuildContext context) =>
@@ -142,9 +141,9 @@ class TimeIndicatorsChild extends ParentDataWidget<_TimeIndicatorParentData> {
   TimeIndicatorsChild({
     required this.time,
     this.alignment = Alignment.centerRight,
-    required Widget child,
+    required super.child,
   })  : assert(time.isValidTimetableTimeOfDay),
-        super(key: ValueKey(time), child: child);
+        super(key: ValueKey(time));
 
   /// The time of day that this widget positioned next to.
   final Duration time;

--- a/lib/src/components/week_indicator.dart
+++ b/lib/src/components/week_indicator.dart
@@ -28,20 +28,19 @@ import '../week.dart';
 class WeekIndicator extends StatelessWidget {
   const WeekIndicator(
     this.week, {
-    Key? key,
+    super.key,
     this.alwaysUseNarrowestVariant = false,
     this.onTap,
     this.style,
-  }) : super(key: key);
+  });
   WeekIndicator.forDate(
     DateTime date, {
-    Key? key,
+    super.key,
     this.alwaysUseNarrowestVariant = false,
     this.onTap,
     this.style,
   })  : assert(date.isValidTimetableDate),
-        week = date.week,
-        super(key: key);
+        week = date.week;
   static Widget forController(
     DateController? controller, {
     Key? key,
@@ -333,11 +332,11 @@ class WeekIndicatorStyle {
 class _WeekIndicatorForController extends StatelessWidget {
   const _WeekIndicatorForController(
     this.controller, {
-    Key? key,
+    super.key,
     this.alwaysUseNarrowestVariant = false,
     this.onTap,
     this.style,
-  }) : super(key: key);
+  });
 
   final DateController? controller;
   final bool alwaysUseNarrowestVariant;

--- a/lib/src/components/weekday_indicator.dart
+++ b/lib/src/components/weekday_indicator.dart
@@ -17,10 +17,9 @@ import '../utils.dart';
 class WeekdayIndicator extends StatelessWidget {
   WeekdayIndicator(
     this.date, {
-    Key? key,
+    super.key,
     this.style,
-  })  : assert(date.isValidTimetableDate),
-        super(key: key);
+  }) : assert(date.isValidTimetableDate);
 
   final DateTime date;
   final WeekdayIndicatorStyle? style;

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -12,7 +12,7 @@ import 'time/overlay.dart';
 
 class TimetableConfig<E extends Event> extends StatefulWidget {
   TimetableConfig({
-    Key? key,
+    super.key,
     this.dateController,
     this.timeController,
     EventProvider<E>? eventProvider,
@@ -22,8 +22,7 @@ class TimetableConfig<E extends Event> extends StatefulWidget {
     this.callbacks,
     this.theme,
     required this.child,
-  })  : eventProvider = eventProvider?.debugChecked,
-        super(key: key);
+  }) : eventProvider = eventProvider?.debugChecked;
 
   final DateController? dateController;
   final TimeController? timeController;

--- a/lib/src/date/controller.dart
+++ b/lib/src/date/controller.dart
@@ -143,7 +143,7 @@ class DatePageValue {
   int get visibleDayCount => visibleRange.visibleDayCount;
 
   final double page;
-  DateTime get date => DateTimeTimetable.dateFromPage(page.floor());
+  DateTime get date => DateTimeTimetable.dateFromPage(page.round());
 
   int get firstVisiblePage => page.floor();
 

--- a/lib/src/date/controller.dart
+++ b/lib/src/date/controller.dart
@@ -197,8 +197,8 @@ class DatePageValue {
 class DefaultDateController extends InheritedWidget {
   const DefaultDateController({
     required this.controller,
-    required Widget child,
-  }) : super(child: child);
+    required super.child,
+  });
 
   final DateController controller;
 

--- a/lib/src/date/date_page_view.dart
+++ b/lib/src/date/date_page_view.dart
@@ -19,11 +19,11 @@ const _precisionErrorTolerance = 1e-5;
 /// a [DefaultDateController] above in the widget tree.
 class DatePageView extends StatefulWidget {
   const DatePageView({
-    Key? key,
+    super.key,
     this.controller,
     this.shrinkWrapInCrossAxis = false,
     required this.builder,
-  }) : super(key: key);
+  });
 
   final DateController? controller;
   final bool shrinkWrapInCrossAxis;
@@ -145,7 +145,7 @@ class _DatePageViewState extends State<DatePageView> {
         onSizeChanged: (size) {
           if (_heights[page] == size.height) return;
           _heights[page] = size.height;
-          WidgetsBinding.instance!.addPostFrameCallback((_) => setState(() {}));
+          WidgetsBinding.instance.addPostFrameCallback((_) => setState(() {}));
         },
         child: child,
       );
@@ -213,16 +213,11 @@ class _MultiDateScrollController extends ScrollController {
 class MultiDateScrollPosition extends ScrollPositionWithSingleContext {
   MultiDateScrollPosition(
     this.owner, {
-    required ScrollPhysics physics,
-    required ScrollContext context,
+    required super.physics,
+    required super.context,
     required this.initialPage,
-    ScrollPosition? oldPosition,
-  }) : super(
-          physics: physics,
-          context: context,
-          initialPixels: null,
-          oldPosition: oldPosition,
-        );
+    super.oldPosition,
+  }) : super(initialPixels: null);
 
   final _MultiDateScrollController owner;
   DateController get controller => owner.controller;

--- a/lib/src/date/month_page_view.dart
+++ b/lib/src/date/month_page_view.dart
@@ -59,7 +59,7 @@ class _MonthPageViewState extends State<MonthPageView> {
             onSizeChanged: (size) {
               if (_heights[page] == size.height) return;
               _heights[page] = size.height;
-              WidgetsBinding.instance!
+              WidgetsBinding.instance
                   .addPostFrameCallback((_) => setState(() {}));
             },
             child: child,

--- a/lib/src/date/scroll_physics.dart
+++ b/lib/src/date/scroll_physics.dart
@@ -5,8 +5,7 @@ import 'date_page_view.dart';
 import 'visible_date_range.dart';
 
 class DateScrollPhysics extends ScrollPhysics {
-  const DateScrollPhysics(this.visibleRangeListenable, {ScrollPhysics? parent})
-      : super(parent: parent);
+  const DateScrollPhysics(this.visibleRangeListenable, {super.parent});
 
   final ValueListenable<VisibleDateRange> visibleRangeListenable;
   VisibleDateRange get visibleRange => visibleRangeListenable.value;

--- a/lib/src/date/visible_date_range.dart
+++ b/lib/src/date/visible_date_range.dart
@@ -13,7 +13,7 @@ abstract class VisibleDateRange {
 
   /// A visible range that shows [visibleDayCount] consecutive days.
   ///
-  /// This range snapps to every `swipeRange` days (defaults to every day) that
+  /// This range snaps to every `swipeRange` days (defaults to every day) that
   /// are aligned to `alignmentDate` (defaults to today).
   ///
   /// When set, swiping is limited from `minDate` to `maxDate` so that both can

--- a/lib/src/event/basic.dart
+++ b/lib/src/event/basic.dart
@@ -14,9 +14,9 @@ class BasicEvent extends Event {
     required this.id,
     required this.title,
     required this.backgroundColor,
-    required DateTime start,
-    required DateTime end,
-  }) : super(start: start, end: end);
+    required super.start,
+    required super.end,
+  });
 
   /// An ID for this event.
   ///
@@ -65,10 +65,10 @@ class BasicEvent extends Event {
 class BasicEventWidget extends StatelessWidget {
   const BasicEventWidget(
     this.event, {
-    Key? key,
+    super.key,
     this.onTap,
     this.margin = const EdgeInsets.only(right: 1),
-  }) : super(key: key);
+  });
 
   /// The event to be displayed.
   final BasicEvent event;
@@ -114,11 +114,11 @@ class BasicEventWidget extends StatelessWidget {
 class BasicAllDayEventWidget extends StatelessWidget {
   const BasicAllDayEventWidget(
     this.event, {
-    Key? key,
+    super.key,
     required this.info,
     this.onTap,
     this.style,
-  }) : super(key: key);
+  });
 
   /// The event to be displayed.
   final BasicEvent event;

--- a/lib/src/event/builder.dart
+++ b/lib/src/event/builder.dart
@@ -12,10 +12,9 @@ class DefaultEventBuilder<E extends Event> extends InheritedWidget {
   DefaultEventBuilder({
     required this.builder,
     AllDayEventBuilder<E>? allDayBuilder,
-    required Widget child,
-  })  : allDayBuilder =
-            allDayBuilder ?? ((context, event, _) => builder(context, event)),
-        super(child: child);
+    required super.child,
+  }) : allDayBuilder =
+            allDayBuilder ?? ((context, event, _) => builder(context, event));
 
   final EventBuilder<E> builder;
   final AllDayEventBuilder<E> allDayBuilder;

--- a/lib/src/event/provider.dart
+++ b/lib/src/event/provider.dart
@@ -72,9 +72,8 @@ extension EventProviderTimetable<E extends Event> on EventProvider<E> {
 class DefaultEventProvider<E extends Event> extends InheritedWidget {
   DefaultEventProvider({
     required EventProvider<E> eventProvider,
-    required Widget child,
-  })  : eventProvider = eventProvider.debugChecked,
-        super(child: child);
+    required super.child,
+  }) : eventProvider = eventProvider.debugChecked;
 
   final EventProvider<E> eventProvider;
 

--- a/lib/src/layouts/multi_date.dart
+++ b/lib/src/layouts/multi_date.dart
@@ -40,7 +40,7 @@ typedef MultiDateTimetableContentBuilder = Widget Function(
 ///   Sunday without dates.
 class MultiDateTimetable<E extends Event> extends StatefulWidget {
   MultiDateTimetable({
-    Key? key,
+    super.key,
     MultiDateTimetableHeaderBuilder? headerBuilder,
     MultiDateTimetableContentBuilder? contentBuilder,
     Widget? contentLeading,
@@ -50,8 +50,7 @@ class MultiDateTimetable<E extends Event> extends StatefulWidget {
           "`contentLeading` can't be used when `contentBuilder` is specified.",
         ),
         contentBuilder =
-            contentBuilder ?? _defaultContentBuilder<E>(contentLeading),
-        super(key: key);
+            contentBuilder ?? _defaultContentBuilder<E>(contentLeading);
 
   final MultiDateTimetableHeaderBuilder headerBuilder;
   static MultiDateTimetableHeaderBuilder
@@ -100,7 +99,7 @@ class _MultiDateTimetableState<E extends Event>
           eventProvider: (visibleDates) =>
               eventProvider(visibleDates).where((it) => it.isPartDay).toList(),
           child: Builder(
-            builder: (contxt) => widget.contentBuilder(
+            builder: (context) => widget.contentBuilder(
               context,
               (newWidth) => setState(() => _leadingWidth = newWidth),
             ),
@@ -113,15 +112,14 @@ class _MultiDateTimetableState<E extends Event>
 
 class MultiDateTimetableHeader<E extends Event> extends StatelessWidget {
   MultiDateTimetableHeader({
-    Key? key,
+    super.key,
     Widget? leading,
     DateWidgetBuilder? dateHeaderBuilder,
     Widget? bottom,
   })  : leading = leading ?? Center(child: WeekIndicator.forController(null)),
         dateHeaderBuilder =
             dateHeaderBuilder ?? ((context, date) => DateHeader(date)),
-        bottom = bottom ?? MultiDateEventHeader<E>(),
-        super(key: key);
+        bottom = bottom ?? MultiDateEventHeader<E>();
 
   final Widget leading;
   final DateWidgetBuilder dateHeaderBuilder;
@@ -143,14 +141,13 @@ class MultiDateTimetableHeader<E extends Event> extends StatelessWidget {
 
 class MultiDateTimetableContent<E extends Event> extends StatelessWidget {
   MultiDateTimetableContent({
-    Key? key,
+    super.key,
     Widget? leading,
     Widget? divider,
     Widget? content,
   })  : leading = leading ?? _DefaultContentLeading(),
         divider = divider ?? VerticalDivider(width: 0),
-        content = content ?? MultiDateContent<E>(),
-        super(key: key);
+        content = content ?? MultiDateContent<E>();
 
   final Widget leading;
   final Widget divider;
@@ -167,7 +164,7 @@ class MultiDateTimetableContent<E extends Event> extends StatelessWidget {
 }
 
 class _DefaultContentLeading extends StatelessWidget {
-  const _DefaultContentLeading({Key? key}) : super(key: key);
+  const _DefaultContentLeading({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/layouts/recurring_multi_date.dart
+++ b/lib/src/layouts/recurring_multi_date.dart
@@ -25,10 +25,9 @@ import 'multi_date.dart';
 ///   concrete dates and be swipeable.
 class RecurringMultiDateTimetable<E extends Event> extends StatelessWidget {
   RecurringMultiDateTimetable({
-    Key? key,
+    super.key,
     WidgetBuilder? timetableBuilder,
-  })  : timetableBuilder = timetableBuilder ?? _defaultTimetableBuilder<E>(),
-        super(key: key);
+  }) : timetableBuilder = timetableBuilder ?? _defaultTimetableBuilder<E>();
 
   final WidgetBuilder timetableBuilder;
   static WidgetBuilder _defaultTimetableBuilder<E extends Event>() {

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -187,8 +187,8 @@ class TimetableThemeData {
 class TimetableTheme extends InheritedWidget {
   const TimetableTheme({
     required this.data,
-    required Widget child,
-  }) : super(child: child);
+    required super.child,
+  });
 
   final TimetableThemeData data;
 

--- a/lib/src/time/controller.dart
+++ b/lib/src/time/controller.dart
@@ -64,7 +64,7 @@ class TimeController extends ValueNotifier<TimeRange> {
   /// The minimum visible duration when zooming in.
   final Duration minDuration;
 
-  /// The maximim visible duration when zooming out.
+  /// The maximum visible duration when zooming out.
   final Duration maxDuration;
 
   /// The maximum range that can be revealed when zooming out.
@@ -128,8 +128,8 @@ class TimeController extends ValueNotifier<TimeRange> {
 class DefaultTimeController extends InheritedWidget {
   const DefaultTimeController({
     required this.controller,
-    required Widget child,
-  }) : super(child: child);
+    required super.child,
+  });
 
   final TimeController controller;
 

--- a/lib/src/time/overlay.dart
+++ b/lib/src/time/overlay.dart
@@ -57,8 +57,8 @@ TimeOverlayProvider mergeTimeOverlayProviders(
 class DefaultTimeOverlayProvider extends InheritedWidget {
   const DefaultTimeOverlayProvider({
     required this.overlayProvider,
-    required Widget child,
-  }) : super(child: child);
+    required super.child,
+  });
 
   final TimeOverlayProvider overlayProvider;
 

--- a/lib/src/time/zoom.dart
+++ b/lib/src/time/zoom.dart
@@ -14,7 +14,7 @@ import 'time_range.dart';
 /// This uses a [TimeController] to maintain its state, which has to be supplied
 /// by a [DefaultTimeController] above in the widget tree.
 class TimeZoom extends StatefulWidget {
-  const TimeZoom({Key? key, required this.child}) : super(key: key);
+  const TimeZoom({super.key, required this.child});
 
   final Widget child;
 
@@ -248,29 +248,17 @@ class _TimeZoomState extends State<TimeZoom>
 class _NoDragSingleChildScrollView extends SingleChildScrollView {
   /// Creates a box in which a single widget can be scrolled.
   const _NoDragSingleChildScrollView({
-    Key? key,
-    Axis scrollDirection = Axis.vertical,
-    bool reverse = false,
-    EdgeInsetsGeometry? padding,
-    ScrollPhysics? physics,
-    ScrollController? controller,
-    Widget? child,
-    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    Clip clipBehavior = Clip.hardEdge,
-    String? restorationId,
-  }) : super(
-          key: key,
-          scrollDirection: scrollDirection,
-          reverse: reverse,
-          padding: padding,
-          controller: controller,
-          primary: false,
-          physics: physics,
-          child: child,
-          dragStartBehavior: dragStartBehavior,
-          clipBehavior: clipBehavior,
-          restorationId: restorationId,
-        );
+    super.key,
+    super.scrollDirection = Axis.vertical,
+    super.reverse = false,
+    super.padding,
+    super.physics,
+    super.controller,
+    super.child,
+    super.dragStartBehavior = DragStartBehavior.start,
+    super.clipBehavior = Clip.hardEdge,
+    super.restorationId,
+  }) : super(primary: false);
 
   @override
   Widget build(BuildContext context) {
@@ -290,28 +278,17 @@ class _NoDragSingleChildScrollView extends SingleChildScrollView {
 
 class _Scrollable extends Scrollable {
   const _Scrollable({
-    Key? key,
-    AxisDirection axisDirection = AxisDirection.down,
-    ScrollController? controller,
-    ScrollPhysics? physics,
-    required ViewportBuilder viewportBuilder,
-    ScrollIncrementCalculator? incrementCalculator,
-    bool excludeFromSemantics = false,
-    int? semanticChildCount,
-    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    String? restorationId,
-  }) : super(
-          key: key,
-          axisDirection: axisDirection,
-          controller: controller,
-          physics: physics,
-          viewportBuilder: viewportBuilder,
-          incrementCalculator: incrementCalculator,
-          excludeFromSemantics: excludeFromSemantics,
-          semanticChildCount: semanticChildCount,
-          dragStartBehavior: dragStartBehavior,
-          restorationId: restorationId,
-        );
+    super.key,
+    super.axisDirection = AxisDirection.down,
+    super.controller,
+    super.physics,
+    required super.viewportBuilder,
+    super.incrementCalculator,
+    super.excludeFromSemantics = false,
+    super.semanticChildCount,
+    super.dragStartBehavior = DragStartBehavior.start,
+    super.restorationId,
+  });
 
   @override
   _ScrollableState createState() => _ScrollableState();
@@ -326,11 +303,11 @@ class _ScrollableState extends ScrollableState {
 // Copied and modified from [OverflowBox].
 class _VerticalOverflowBox extends SingleChildRenderObjectWidget {
   const _VerticalOverflowBox({
-    Key? key,
+    super.key,
     required this.height,
     required this.offset,
-    Widget? child,
-  }) : super(key: key, child: child);
+    super.child,
+  });
 
   final double height;
   final double offset;
@@ -417,10 +394,10 @@ class _RenderVerticalOverflowBox extends RenderShiftedBox {
 // Copied and modified from https://github.com/flutter/flutter/blob/f4abaa0735eba4dfd8f33f73363911d63931fe03/packages/flutter/lib/src/gestures/scale.dart
 class _ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   _ScaleGestureRecognizer({
-    Object? debugOwner,
-    Set<PointerDeviceKind>? supportedDevices,
+    super.debugOwner,
+    super.supportedDevices,
     this.dragStartBehavior = DragStartBehavior.down,
-  }) : super(debugOwner: debugOwner, supportedDevices: supportedDevices);
+  });
 
   DragStartBehavior dragStartBehavior;
   GestureScaleStartCallback? onStart;
@@ -789,17 +766,12 @@ class _ScrollController extends ScrollController {
 
 class _ScrollPositionWithSingleContext extends ScrollPositionWithSingleContext {
   _ScrollPositionWithSingleContext({
-    required ScrollPhysics physics,
-    required ScrollContext context,
+    required super.physics,
+    required super.context,
     required this.getOffset,
     required this.setOffset,
-    ScrollPosition? oldPosition,
-  }) : super(
-          physics: physics,
-          context: context,
-          keepScrollOffset: false,
-          oldPosition: oldPosition,
-        ) {
+    super.oldPosition,
+  }) : super(keepScrollOffset: false) {
     correctPixels(getOffset());
   }
 

--- a/lib/src/utils/size_reporting_widget.dart
+++ b/lib/src/utils/size_reporting_widget.dart
@@ -4,10 +4,10 @@ import 'package:flutter/widgets.dart';
 // Copied and modified from https://github.com/Limbou/expandable_page_view/blob/d692cff38f9e098ad5c020d80123a13ab2a53083/lib/size_reporting_widget.dart
 class SizeReportingWidget extends StatefulWidget {
   const SizeReportingWidget({
-    Key? key,
+    super.key,
     required this.onSizeChanged,
     required this.child,
-  }) : super(key: key);
+  });
 
   final ValueChanged<Size> onSizeChanged;
   final Widget child;
@@ -22,10 +22,10 @@ class _SizeReportingWidgetState extends State<SizeReportingWidget> {
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance!.addPostFrameCallback((_) => _notifySize());
+    WidgetsBinding.instance.addPostFrameCallback((_) => _notifySize());
     return NotificationListener<SizeChangedLayoutNotification>(
       onNotification: (_) {
-        WidgetsBinding.instance!.addPostFrameCallback((_) => _notifySize());
+        WidgetsBinding.instance.addPostFrameCallback((_) => _notifySize());
         return true;
       },
       child: SizeChangedLayoutNotifier(
@@ -83,10 +83,10 @@ class ImmediateSizeReportingOverflowPage extends StatelessWidget {
 
 class ImmediateSizeReportingWidget extends SingleChildRenderObjectWidget {
   const ImmediateSizeReportingWidget({
-    Key? key,
+    super.key,
     required this.onSizeChanged,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// Called during layout!
   final ValueChanged<Size> onSizeChanged;
@@ -125,10 +125,10 @@ class _ImmediateSizeReportingRenderObject extends RenderProxyBox {
 /// A widget that requests its height during layout via [heightGetter].
 class ImmediateSizedBox extends SingleChildRenderObjectWidget {
   const ImmediateSizedBox({
-    Key? key,
+    super.key,
     required this.heightGetter,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   final ValueGetter<double> heightGetter;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0-alpha.7
 homepage: https://github.com/JonasWanke/timetable
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.8.0'
+  sdk: '>=2.17.0-266.8.beta <3.0.0'
+  flutter: '>=2.13.0-0.4.pre'
 
 dependencies:
   async: ^2.6.0
@@ -21,7 +21,7 @@ dependencies:
   tuple: ^2.0.0
 
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   glados: ^1.0.0


### PR DESCRIPTION
This PR updates `timetable` to Flutter 3.
The following things have been changed:
 - Upgrade dependencies
 - Migrate to new `super.xxx` syntax
 - Fix some small typos in documentation
 - Fix `WidgetsBinding.instance!` warnings (bug reports will certainly arrive soon-ish if not fixed)

This PR has the following side-effects:
 - Lint has much more stuff to complain about (mostly `unused_element`, e.g., in `lib\src\time\zoom.dart`)
 - A wrong `context` being used? (I will add a comment under this PR highlighting the line I mean... Just noticed that by chance and thought, that might be wrong... If it was right before and uses the wrong `context` now, just tell me and I will revert that specific change)
 - Hopefully no others