### PR TITLE
refactor!: make Event an interface

### DIFF
--- a/example/lib/utils.dart
+++ b/example/lib/utils.dart
@@ -31,7 +31,7 @@ void initDebugOverlay() {
 }
 
 class ExampleApp extends StatelessWidget {
-  const ExampleApp({required this.child});
+  const ExampleApp({super.key, required this.child});
 
   final Widget child;
 

--- a/lib/src/event/basic.dart
+++ b/lib/src/event/basic.dart
@@ -2,6 +2,7 @@ import 'package:black_hole_flutter/black_hole_flutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../utils.dart';
 import 'all_day.dart';
 import 'event.dart';
 
@@ -11,14 +12,14 @@ import 'event.dart';
 ///
 /// * [BasicEventWidget], which can display instances of [BasicEvent].
 @immutable
-class BasicEvent extends Event {
+class BasicEvent with Diagnosticable implements Event {
   const BasicEvent({
     required this.id,
     required this.title,
     required this.backgroundColor,
-    required super.start,
-    required super.end,
-  });
+    required this.start,
+    required this.end,
+  }) : assert(start <= end);
 
   /// An ID for this event.
   ///
@@ -36,6 +37,17 @@ class BasicEvent extends Event {
   ///
   /// This is currently used by [BasicEventWidget] and [BasicAllDayEventWidget].
   final Color backgroundColor;
+
+  /// Start of the event; inclusive.
+  @override
+  final DateTime start;
+
+  /// End of the event; exclusive.
+  @override
+  final DateTime end;
+
+  @override
+  bool get isAllDay => end.difference(start).inDays >= 1;
 
   BasicEvent copyWith({
     Object? id,
@@ -55,6 +67,7 @@ class BasicEvent extends Event {
 
   @override
   int get hashCode => Object.hash(super.hashCode, title, backgroundColor);
+
   @override
   bool operator ==(Object other) =>
       other is BasicEvent &&
@@ -68,6 +81,16 @@ class BasicEvent extends Event {
     properties.add(DiagnosticsProperty('id', id));
     properties.add(StringProperty('title', title));
     properties.add(ColorProperty('backgroundColor', backgroundColor));
+    properties.add(DiagnosticsProperty('start', start));
+    properties.add(DiagnosticsProperty('end', end));
+    properties.add(
+      FlagProperty(
+        'isAllDay',
+        value: isAllDay,
+        ifTrue: 'all-day',
+        ifFalse: 'part-day',
+      ),
+    );
   }
 }
 
@@ -232,6 +255,7 @@ class BasicAllDayEventWidgetStyle {
 
   @override
   int get hashCode => Object.hash(margin, radii, padding, textStyle);
+
   @override
   bool operator ==(Object other) {
     return other is BasicAllDayEventWidgetStyle &&

--- a/lib/src/event/event.dart
+++ b/lib/src/event/event.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../utils.dart';
 import 'basic.dart';
 
@@ -8,34 +6,14 @@ import 'basic.dart';
 /// See also:
 ///
 /// * [BasicEvent], which provides a basic implementation to get you started.
-abstract class Event with Diagnosticable {
-  const Event({
-    required this.start,
-    required this.end,
-  }) : assert(start <= end);
-
+abstract interface class Event {
   /// Start of the event; inclusive.
-  final DateTime start;
+  DateTime get start;
 
   /// End of the event; exclusive.
-  final DateTime end;
+  DateTime get end;
 
-  bool get isAllDay => end.difference(start).inDays >= 1;
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty('start', start));
-    properties.add(DiagnosticsProperty('end', end));
-    properties.add(
-      FlagProperty(
-        'isAllDay',
-        value: isAllDay,
-        ifTrue: 'all-day',
-        ifFalse: 'part-day',
-      ),
-    );
-  }
+  bool get isAllDay;
 }
 
 extension EventExtension on Event {

--- a/lib/src/time/zoom.dart
+++ b/lib/src/time/zoom.dart
@@ -410,7 +410,7 @@ class _RenderVerticalOverflowBox extends RenderShiftedBox {
 class _ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   _ScaleGestureRecognizer({
     super.debugOwner,
-    // ignore: unused_element
+    // ignore: unused_element_parameter
     this.dragStartBehavior = DragStartBehavior.down,
   });
 

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -74,7 +74,15 @@ void main() {
   });
 }
 
-class _TestEvent extends Event {
-  const _TestEvent(DateTime start, DateTime end)
-      : super(start: start, end: end);
+class _TestEvent implements Event {
+  const _TestEvent(this.start, this.end);
+
+  @override
+  final DateTime start;
+
+  @override
+  final DateTime end;
+
+  @override
+  bool get isAllDay => end.difference(start).inDays >= 1;
 }


### PR DESCRIPTION
This is a breaking change!
As it stands, the `Event` class cannot be used in conjunction with `freezed`.
In order to fix this, I had two options:
1. Make `Event` a real interface
2. Introduce an interface `IEvent` (or whatever) that is now the real interface and use that instead across the codebase

Since 2. seems to be a rather huge refactor, I chose option 1.
Of course, since 2. may be non-breaking, I can change this PR accordingly, if needed/wanted.